### PR TITLE
Bookmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.MinTreeBookmarks

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ MinTree requires Vim version 8.0+, and it must be compiled with the `folding`, `
 
 ## Installation
 
-Use your favorite plugin manager to install this plugin. My personal favorite is [vim-plug](https://github.com/junegunn/vim-plug). In your **`.vimrc`**, add the following line.
+Use your favorite plugin manager to install this plugin. If you have no favorite, I recommend [vim-plug](https://github.com/junegunn/vim-plug). In your **`.vimrc`**, add the following line.
+
 ```vim
 Plug 'git@github.com:PhilRunninger/mintree.git'
 ```
@@ -24,14 +25,15 @@ This command opens a buffer with the name **`=MinTree=`** in the current window,
 This command searches the **`=MinTree=`** buffer for the given path. If no path was given, it looks for the current buffer. If not found in the current tree, a new one is created to show the file being sought.
 
 The commands can be assigned to a key, and these assignments are left to the user, so as not to interfere with any existing mappings. For example,
-```
+
+```vim
 nnoremap <leader>o :MinTree<CR>
 nnoremap <leader>f :MinTreeFind<CR>
 ```
 
-## Key Mappings
+## Key Bindings
 
-The following key mappings are used only within the **`=MinTree=`** buffer. They are configurable by setting the corresponding global variables.
+The following key bindings are used only within the **`=MinTree=`** buffer. They are configurable by setting the corresponding global variables.
 
 Default Key | Variable                   | Function
 ---         | ---                        | ---
@@ -51,11 +53,14 @@ Default Key | Variable                   | Function
 **`r`**     | `g:MinTreeRefresh`         | Refresh the directory under the cursor, or the directory containing the file under the cursor.
 **`R`**     | `g:MinTreeRefreshRoot`     | Refresh the whole tree.
 **`I`**     | `g:MinTreeToggleHidden`    | Toggles the display of hidden files, those starting with a period, or marked hidden in Windows.
+**`m`**     | `g:MinTreeCreateMark`      | Creates a single-letter bookmark for the current node.
+**`'`**     | `g:MinTreeGotoMark`        | Displays all bookmarks, and opens the one selected.
+**`dm`**    | `g:MinTreeCreateMark`      | Displays all bookmarks, and deletes the ones selected. This is the same variable used for creating bookmarks, but prefixed with a `d`.
 **`q`**     | `g:MinTreeExit`            | Exit the MinTree, and return to the previous buffer.
 
 ## Settings
 
-The following settings can be used to customize the commands that gather files and directories for your unique situation.
+The following variables define the OS commands that gather files and directories. If necessary, you can customize them for your unique situation.
 
 Variable | Default
 --- | ---

--- a/README.md
+++ b/README.md
@@ -60,17 +60,19 @@ Default Key | Variable                   | Function
 
 ## Settings
 
-The following variables define the OS commands that gather files and directories. If necessary, you can customize them for your unique situation.
+* The following variables define the OS commands that gather files and directories. If necessary, you can customize them for your unique situation.
 
-Variable | Default
---- | ---
-**`g:MinTreeDirAll`**<br>returns all files/dirs in the `%s` directory. | Windows: `dir /b %s`<br>others: `ls -A %s \| sort -f`
-**`g:MinTreeDirNoHidden`**<br>returns all non hidden files/dirs in the `%s` directory. | Windows: `dir /b /a:-h %s \| findstr -v "^\."`<br>others: `ls %s \| sort -f`
-**`g:MinTreeShowHidden`**<br>sets which of the above two commands to use by default. | 0
+    Variable | Default
+    --- | ---
+    **`g:MinTreeDirAll`**<br>returns all files/dirs in the `%s` directory. | Windows: `dir /b %s`<br>others: `ls -A %s \| sort -f`
+    **`g:MinTreeDirNoHidden`**<br>returns all non hidden files/dirs in the `%s` directory. | Windows: `dir /b /a:-h %s \| findstr -v "^\."`<br>others: `ls %s \| sort -f`
+    **`g:MinTreeShowHidden`**<br>sets which of the above two commands to use by default. | 0
 
-The characters used to indicate whether a directory is collapsed or expanded can be customized with these two variables
+* The characters used to indicate whether a directory is collapsed or expanded can be customized with these two variables
 
-Variable | Default
---- | ---
-**`g:MinTreeExpanded`**<br>Character used to indicate a directory's contents are being shown. | `▾`
-**`g:MinTreeCollapsed`**<br>Character used to indicate a directory's contents are hidden or not yet retrieved. | `▸`
+    Variable | Default
+    --- | ---
+    **`g:MinTreeExpanded`**<br>Character used to indicate a directory's contents are being shown. | `▾`
+    **`g:MinTreeCollapsed`**<br>Character used to indicate a directory's contents are hidden or not yet retrieved. | `▸`
+
+* To change the indentation level, change the value of **`g:MinTreeIndentSize`**. It is the number of spaces to use for each level of indentation, and its default value is `2`.

--- a/autoload/mintree.vim
+++ b/autoload/mintree.vim
@@ -1,12 +1,13 @@
-function! mintree#runningWindows()
+" vim: foldmethod=marker
+function! mintree#runningWindows()    " {{{1
     return has("win16") || has("win32") || has("win64")
 endfunction
 
-function! mintree#indent(line)
+function! mintree#indent(line)    " {{{1
     return str2nr(getline(a:line)[0:1])
 endfunction
 
-function! mintree#fullPath(line)
+function! mintree#fullPath(line)    " {{{1
     let l:pos = getpos('.')
     execute 'normal! '.a:line.'gg'
     let l:indent = mintree#indent(a:line)
@@ -21,6 +22,6 @@ function! mintree#fullPath(line)
     return l:file
 endfunction
 
-function! mintree#slash()
+function! mintree#slash()    " {{{1
     return (mintree#runningWindows() ? '\' : '/')
 endfunction

--- a/autoload/mintree.vim
+++ b/autoload/mintree.vim
@@ -11,11 +11,11 @@ function! mintree#fullPath(line)    " {{{1
     let l:pos = getpos('.')
     execute 'normal! '.a:line.'gg'
     let l:indent = mintree#indent(a:line)
-    let l:file = strcharpart(getline(a:line),3 + (l:indent+1)*2)
+    let l:file = strcharpart(getline(a:line),3 + (l:indent+1)*1)
     while l:indent > 0
         let l:indent -= 1
         call search(printf('^%02d', l:indent),'bW')
-        let l:parent = strcharpart(getline('.'),3 + (l:indent+1)*2)
+        let l:parent = strcharpart(getline('.'),3 + (l:indent+1)*1)
         let l:file = l:parent . l:file
     endwhile
     call setpos('.', l:pos)

--- a/autoload/mintree.vim
+++ b/autoload/mintree.vim
@@ -3,19 +3,26 @@ function! mintree#runningWindows()    " {{{1
     return has("win16") || has("win32") || has("win64")
 endfunction
 
-function! mintree#indent(line)    " {{{1
-    return str2nr(getline(a:line)[0:1])
+let g:MinTreeMetadataWidth = 4   " {{{1
+let g:MinTreeIndentDigits = 3
+
+function! mintree#indent(line)    " {{{2
+    return str2nr(getline(a:line)[0:(g:MinTreeIndentDigits-1)])
+endfunction
+
+function! mintree#metadataString(indent, is_open)   " {{{2
+    return printf("%03d%s", a:indent, a:is_open)
 endfunction
 
 function! mintree#fullPath(line)    " {{{1
     let l:pos = getpos('.')
     execute 'normal! '.a:line.'gg'
     let l:indent = mintree#indent(a:line)
-    let l:file = strcharpart(getline(a:line),3 + (l:indent+1)*1)
+    let l:file = strcharpart(getline(a:line),g:MinTreeMetadataWidth + 1 + l:indent*g:MinTreeIndentSize)
     while l:indent > 0
         let l:indent -= 1
-        call search(printf('^%02d', l:indent),'bW')
-        let l:parent = strcharpart(getline('.'),3 + (l:indent+1)*1)
+        call search(printf('^%s', mintree#metadataString(l:indent,'')),'bW')
+        let l:parent = strcharpart(getline('.'),g:MinTreeMetadataWidth + 1 + l:indent*g:MinTreeIndentSize)
         let l:file = l:parent . l:file
     endwhile
     call setpos('.', l:pos)

--- a/ftplugin/mintree.vim
+++ b/ftplugin/mintree.vim
@@ -1,3 +1,5 @@
+" vim: foldmethod=marker
+" Settings   {{{1
 setlocal nomodifiable
 setlocal buftype=nofile noswapfile
 setlocal nowrap nonumber nolist
@@ -5,7 +7,7 @@ setlocal conceallevel=3 concealcursor=nvic
 setlocal foldcolumn=0 foldmethod=expr foldexpr=MinTreeFoldLevel(v:lnum)
 setlocal foldtext=substitute(getline(v:foldstart)[3:],g:MinTreeExpanded,g:MinTreeCollapsed,'')
 
-function! MinTreeFoldLevel(lnum)
+function! MinTreeFoldLevel(lnum)   " {{{1
     let l:current_indent = mintree#indent(a:lnum)
     if a:lnum == line('$')
         let l:result = ['<', l:current_indent]

--- a/ftplugin/mintree.vim
+++ b/ftplugin/mintree.vim
@@ -5,7 +5,7 @@ setlocal buftype=nofile noswapfile
 setlocal nowrap nonumber nolist
 setlocal conceallevel=3 concealcursor=nvic
 setlocal foldcolumn=0 foldmethod=expr foldexpr=MinTreeFoldLevel(v:lnum)
-setlocal foldtext=substitute(getline(v:foldstart)[3:],g:MinTreeExpanded,g:MinTreeCollapsed,'')
+execute "setlocal foldtext=substitute(getline(v:foldstart)[".g:MinTreeMetadataWidth.":],g:MinTreeExpanded,g:MinTreeCollapsed,'')"
 
 function! MinTreeFoldLevel(lnum)   " {{{1
     let l:current_indent = mintree#indent(a:lnum)

--- a/plugin/mintree.vim
+++ b/plugin/mintree.vim
@@ -91,10 +91,10 @@ function! s:_locateFile(path, indent, line, get_children)
     else
         let l:part = a:path[0]
         let [_,l:end] = s:FoldLimits(a:line)
-        if search(printf('^%02d. *%s %s%s', a:indent+1, g:MinTreeCollapsed, l:part ,mintree#slash()), 'W', l:end) > 0 && a:get_children
+        if search(printf('^%02d. *%s%s%s', a:indent+1, g:MinTreeCollapsed, l:part ,mintree#slash()), 'W', l:end) > 0 && a:get_children
             call s:GetChildren(line('.'))
             return s:_locateFile(a:path[1:], a:indent+1, line('.'), a:get_children)
-        elseif search(printf('^%02d. *%s %s%s', a:indent+1, g:MinTreeExpanded, l:part ,mintree#slash()), 'W', l:end) > 0
+        elseif search(printf('^%02d. *%s%s%s', a:indent+1, g:MinTreeExpanded, l:part ,mintree#slash()), 'W', l:end) > 0
             return s:_locateFile(a:path[1:], a:indent+1, line('.'), a:get_children)
         elseif search(printf('^%02d. *%s$', a:indent+1, l:part), 'W', l:end) > 0
             return line('.')
@@ -111,7 +111,7 @@ function! s:MinTreeOpen(path)   " {{{1
 
     setlocal modifiable
     %delete
-    call setline(1, printf('000%s %s', g:MinTreeCollapsed, s:root))
+    call setline(1, printf('000%s%s', g:MinTreeCollapsed, s:root))
     call s:ActivateNode(1)
 
     call map(copy(s:key_bindings), {key, cmd -> execute("nnoremap <silent> <buffer> ".key." ".cmd)})
@@ -151,7 +151,7 @@ function! s:GetChildren(line)   " {{{1
     let l:parent = mintree#fullPath(a:line)
     let l:children = split(system(printf(s:DirCmd(), shellescape(l:parent))), '\n')
     let l:prefix = printf('%02d0%s',l:indent+1, repeat(' ', (l:indent+1)*2))
-    call map(l:children, {idx,val -> printf((isdirectory(l:parent.mintree#slash().val) ? '%s'.g:MinTreeCollapsed.' %s'.mintree#slash(): '%s  %s'), l:prefix, val)})
+    call map(l:children, {idx,val -> printf((isdirectory(l:parent.mintree#slash().val) ? '%s'.g:MinTreeCollapsed.'%s'.mintree#slash(): '%s %s'), l:prefix, val)})
     setlocal modifiable
     call append(a:line, l:children)
     call setline(a:line, substitute(getline(a:line),g:MinTreeCollapsed,g:MinTreeExpanded,''))

--- a/plugin/mintree.vim
+++ b/plugin/mintree.vim
@@ -1,8 +1,11 @@
+" vim: foldmethod=marker
+" Compatibility Check   {{{1
 if !has("folding") && !has("conceal") && !has("lambda")
     echomsg "MinTree requires Vim 8.0+, and to be compiled with the +folding, +conceal, and +lambda features."
     finish
 endif
 
+" Initialization   {{{1
 let s:MinTreeBuffer = '=MinTree='
 let g:MinTreeCollapsed = get(g:, 'MinTreeCollapsed', '▸')
 let g:MinTreeExpanded = get(g:, 'MinTreeExpanded', '▾')
@@ -30,7 +33,7 @@ let s:key_bindings =
 command! -n=? -complete=dir MinTree :call <SID>MinTree('<args>')
 command! -n=? -complete=file MinTreeFind :call <SID>MinTreeFind('<args>')
 
-function! s:MinTree(path)
+function! s:MinTree(path)   " {{{1
     if bufexists(s:MinTreeBuffer) && (empty(a:path) || simplify(fnamemodify(a:path, ':p')) == s:root)
         execute 'buffer '.s:MinTreeBuffer
     else
@@ -39,7 +42,7 @@ function! s:MinTree(path)
     call s:UpdateOpen()
 endfunction
 
-function! s:MinTreeFind(path)
+function! s:MinTreeFind(path)   " {{{1
     let l:path = empty(a:path) ? expand('%:p') : a:path
     if exists("s:root") && stridx(l:path, s:root) == 0 && bufexists(s:MinTreeBuffer)
         execute 'buffer '.s:MinTreeBuffer
@@ -56,7 +59,7 @@ function! s:MinTreeFind(path)
     endif
 endfunction
 
-function! s:UpdateOpen()
+function! s:UpdateOpen()   " {{{1
     let l:pos = getpos('.')
     setlocal modifiable
     normal gg0llGr0
@@ -74,7 +77,7 @@ function! s:UpdateOpen()
     call setpos('.', l:pos)
 endfunction
 
-function! s:LocateFile(path,get_children)
+function! s:LocateFile(path,get_children)   " {{{1
     return s:_locateFile(split(a:path[len(s:root):],mintree#slash()), 0, 1, a:get_children)
 endfunction
 
@@ -97,7 +100,7 @@ function! s:_locateFile(path, indent, line, get_children)
     endif
 endfunction
 
-function! s:MinTreeOpen(path)
+function! s:MinTreeOpen(path)   " {{{1
     let s:root = simplify(fnamemodify(a:path, ':p'))
     execute 'silent buffer ' . bufnr(s:MinTreeBuffer, 1)
     set ft=mintree
@@ -110,7 +113,7 @@ function! s:MinTreeOpen(path)
     call map(copy(s:key_bindings), {key, cmd -> execute("nnoremap <silent> <buffer> ".key." ".cmd)})
 endfunction
 
-function! s:ActivateNode(line)
+function! s:ActivateNode(line)   " {{{1
     if getline(a:line) =~ g:MinTreeCollapsed
         call s:GetChildren(a:line)
         normal! zO
@@ -122,7 +125,7 @@ function! s:ActivateNode(line)
     endif
 endfunction
 
-function! s:OpenFile(windowCmd, line)
+function! s:OpenFile(windowCmd, line)   " {{{1
     let l:path = mintree#fullPath(a:line)
     if l:path !~ escape(mintree#slash(),'\').'$'
         buffer #
@@ -131,7 +134,7 @@ function! s:OpenFile(windowCmd, line)
     endif
 endfunction
 
-function! s:GetChildren(line)
+function! s:GetChildren(line)   " {{{1
     let l:indent = mintree#indent(a:line)
     let l:parent = mintree#fullPath(a:line)
     let l:children = split(system(printf(s:DirCmd(), shellescape(l:parent))), '\n')
@@ -144,18 +147,18 @@ function! s:GetChildren(line)
     return len(l:children)
 endfunction
 
-function! s:CloseParent(line)
+function! s:CloseParent(line)   " {{{1
     if foldlevel(a:line) > 0
         normal zc
         execute 'normal! '.foldclosed(a:line).'gg'
     endif
 endfunction
 
-function! s:GoToParent(line)
+function! s:GoToParent(line)   " {{{1
     call search(printf('^%02d', mintree#indent(a:line)-1),'bW')
 endfunction
 
-function! s:GoToSibling(delta, stop_when)
+function! s:GoToSibling(delta, stop_when)   " {{{1
     let l:line = line('.')
     let l:destination = l:line
     let l:indent = mintree#indent(l:line)
@@ -173,7 +176,7 @@ function! s:GoToSibling(delta, stop_when)
     execute 'normal! '.l:destination.'gg'
 endfunction
 
-function! s:OpenRecursively(line)
+function! s:OpenRecursively(line)   " {{{1
     if a:line == 1
         let l:end = line('$')+1
     elseif getline(a:line) =~ g:MinTreeCollapsed
@@ -198,7 +201,7 @@ function! s:OpenRecursively(line)
     call s:UpdateOpen()
 endfunction
 
-function! s:Refresh(line)
+function! s:Refresh(line)   " {{{1
     let [l:start,l:end] = s:FoldLimits(a:line)
     let l:open_folders = map(filter(range(l:start+1,l:end), {_,l->getline(l)=~g:MinTreeExpanded && foldclosed(l)==-1}), {_,l->mintree#fullPath(l)})
     setlocal modifiable
@@ -211,7 +214,7 @@ function! s:Refresh(line)
     setlocal nomodifiable
 endfunction
 
-function! s:FoldLimits(line)
+function! s:FoldLimits(line)   " {{{1
     execute 'normal! '.a:line.'gg'
     let l:is_fold_open = foldclosed(a:line) == -1
     if l:is_fold_open
@@ -224,7 +227,7 @@ function! s:FoldLimits(line)
     return l:limits
 endfunction
 
-function! s:ToggleHidden()
+function! s:ToggleHidden()   " {{{1
     let g:MinTreeShowHidden = !g:MinTreeShowHidden
     call s:Refresh(1)
 endfunction

--- a/plugin/mintree.vim
+++ b/plugin/mintree.vim
@@ -31,6 +31,7 @@ let s:key_bindings =
     \  get(g:, 'MinTreeExit',            'q'): ":buffer #<CR>",
     \  get(g:, 'MinTreeCreateMark',      'm'): ":call <SID>CreateMark(line('.'))<CR>",
     \  get(g:, 'MinTreeGotoMark',        "'"): ":call <SID>GotoMark()<CR>",
+    \  'd'.get(g:, 'MinTreeCreateMark',  "m"): ":call <SID>DeleteMarks()<CR>",
     \ }
 
 command! -n=? -complete=dir MinTree :call <SID>MinTree('<args>')
@@ -287,6 +288,24 @@ function! s:GotoMark()   " {{{1
             echomsg "Mark ".l:mark." is not set"
         endif
     endif
+endfunction
+
+function! s:DeleteMarks()   " {{{1
+    let l:bookmarks = s:_readMarks()
+    for key in sort(keys(l:bookmarks))
+        echomsg key.": ".l:bookmarks[key]
+    endfor
+    let l:marks = input("Which mark(s) to delete: (* for all) ")
+    if l:marks == '*'
+        let l:bookmarks = {}
+    else
+        for l:mark in split(l:marks, '\zs')
+            if has_key(l:bookmarks, l:mark)
+                call remove(l:bookmarks, l:mark)
+            endif
+        endfor
+    endif
+    call writefile([string(l:bookmarks)], s:BookmarksFile)
 endfunction
 
 function! s:_readMarks()   " {{{1

--- a/plugin/mintree.vim
+++ b/plugin/mintree.vim
@@ -150,7 +150,7 @@ function! s:GetChildren(line)   " {{{1
     let l:indent = mintree#indent(a:line)
     let l:parent = mintree#fullPath(a:line)
     let l:children = split(system(printf(s:DirCmd(), shellescape(l:parent))), '\n')
-    let l:prefix = printf('%02d0%s',l:indent+1, repeat(' ', (l:indent+1)*2))
+    let l:prefix = printf('%02d0%s',l:indent+1, repeat(' ', (l:indent+1)*1))
     call map(l:children, {idx,val -> printf((isdirectory(l:parent.mintree#slash().val) ? '%s'.g:MinTreeCollapsed.'%s'.mintree#slash(): '%s %s'), l:prefix, val)})
     setlocal modifiable
     call append(a:line, l:children)

--- a/plugin/mintree.vim
+++ b/plugin/mintree.vim
@@ -138,7 +138,11 @@ function! s:_openFile(windowCmd, path)   " {{{1
     if a:path !~ escape(mintree#slash(),'\').'$'
         buffer #
         execute a:windowCmd
-        execute 'edit '.l:path
+        if bufnr(a:path) == -1
+            execute 'edit '.a:path
+        else
+            execute 'buffer '.a:path
+        endif
     endif
 endfunction
 

--- a/syntax/mintree.vim
+++ b/syntax/mintree.vim
@@ -2,8 +2,8 @@ let s:Arrows = '['.g:MinTreeCollapsed.g:MinTreeExpanded.']'
 
 execute 'syntax match MinTreeArrows #'.s:Arrows.'\ze.*# containedin=MinTreeDir'
 execute 'syntax match MinTreeDir #'.s:Arrows.'.*#'
-syntax match MinTreeMetaData #^\d\d[01]# conceal containedin=MinTreeFileIsOpen
-syntax match MinTreeFileIsOpen #^\d\d1.*#hs=s+4 contains=MinTreeMetaData
+execute 'syntax match MinTreeMetaData #^'.repeat('\d',g:MinTreeMetadataWidth-1).'[01]# conceal containedin=MinTreeFileIsOpen'
+execute 'syntax match MinTreeFileIsOpen  #^'.repeat('\d',g:MinTreeMetadataWidth-1).'1.*#hs=s+4 contains=MinTreeMetaData'
 
 highlight default link MinTreeDir Directory
 highlight default link MinTreeArrows Statement

--- a/syntax/mintree.vim
+++ b/syntax/mintree.vim
@@ -1,6 +1,6 @@
 let s:Arrows = '['.g:MinTreeCollapsed.g:MinTreeExpanded.']'
 
-execute 'syntax match MinTreeArrows #'.s:Arrows.'\ze .*# containedin=MinTreeDir'
+execute 'syntax match MinTreeArrows #'.s:Arrows.'\ze.*# containedin=MinTreeDir'
 execute 'syntax match MinTreeDir #'.s:Arrows.'.*#'
 syntax match MinTreeMetaData #^\d\d[01]# conceal containedin=MinTreeFileIsOpen
 syntax match MinTreeFileIsOpen #^\d\d1.*#hs=s+4 contains=MinTreeMetaData


### PR DESCRIPTION
Closes #2.

Instead of using commands for showing, and deleting marks, these actions are done with key binding.

## Default Key Bindings
- `m` create a bookmark
- `'` open a bookmark
- `dm` delete a bookmark

## Bonus
- `g:MinTreeIndentSize` can be altered to change the number of spaces per indentation level.
- For developers only, these two variables will reduce the number of places in the code that need to be touched when adding items to the metadata:
    - `g:MinTreeMetadataWidth` is the number of characters at the beginning of the line reserved for metadata
    - `g:MinTreeIndentDigits` is the number of characters of metadata used for the indent level